### PR TITLE
Use flit_core as the build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 module = "vecrec"


### PR DESCRIPTION
Don’t require all of `flit` to build a wheel.

https://flit.pypa.io/en/stable/pyproject_toml.html